### PR TITLE
feat: support major version aliases for engine version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ Each command has full help via `imposter <command> --help`.
 | `imposter workspace ...` | Manage workspaces for remote deployments. |
 | `imposter version` | Print CLI and engine version info. |
 
+### Engine version
+
+Commands that run or fetch an engine take `-v` / `--version`. Pin an exact release, or take the shorthand:
+
+```shell
+imposter up -v 5        # latest native engine
+imposter up -v 4        # latest JVM engine
+imposter up -v 5.21.3   # that exact release
+```
+
+Defaults to `latest`. `-v 5` also picks the native engine for you, so there's no need to pass `-t native` as well. To pin it per project, set `version:` in your [config](./docs/config.md).
+
 ### Healthcheck
 
 ```shell

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -77,7 +77,7 @@ If CONFIG_DIR is not specified, the current working directory is used.`,
 func init() {
 	bundleCmd.Flags().StringVarP(&bundleFlags.output, "output", "o", "", "The destination to write the bundle to. If using the 'docker' engine type, this must be a valid image name. Otherwise, this must be a path to a writeable file. If not specified, a name is generated.")
 	bundleCmd.Flags().StringVarP(&bundleFlags.engineType, "engine-type", "t", "", "Imposter engine type (valid: awslambda,docker,jvm)")
-	bundleCmd.Flags().StringVarP(&bundleFlags.engineVersion, "version", "v", "", "Imposter engine version (default \"latest\")")
+	bundleCmd.Flags().StringVarP(&bundleFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
 	bundleCmd.Flags().StringVarP(&bundleFlags.architecture, "architecture", "a", awslambda.DefaultLambdaArch, "Target CPU architecture for the awslambda engine bundle (amd64 or arm64). Ignored by other engine types.")
 
 	_ = bundleCmd.MarkFlagRequired("engine-type")

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -77,7 +77,7 @@ If CONFIG_DIR is not specified, the current working directory is used.`,
 func init() {
 	bundleCmd.Flags().StringVarP(&bundleFlags.output, "output", "o", "", "The destination to write the bundle to. If using the 'docker' engine type, this must be a valid image name. Otherwise, this must be a path to a writeable file. If not specified, a name is generated.")
 	bundleCmd.Flags().StringVarP(&bundleFlags.engineType, "engine-type", "t", "", "Imposter engine type (valid: awslambda,docker,jvm)")
-	bundleCmd.Flags().StringVarP(&bundleFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
+	bundleCmd.Flags().StringVarP(&bundleFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"4\" or \"5\" (latest of that engine line) or \"latest\" (default \"latest\")")
 	bundleCmd.Flags().StringVarP(&bundleFlags.architecture, "architecture", "a", awslambda.DefaultLambdaArch, "Target CPU architecture for the awslambda engine bundle (amd64 or arm64). Ignored by other engine types.")
 
 	_ = bundleCmd.MarkFlagRequired("engine-type")

--- a/cmd/engine_pull.go
+++ b/cmd/engine_pull.go
@@ -41,7 +41,7 @@ If version is not specified, it defaults to 'latest'.`,
 		} else {
 			pullPolicy = engine.PullIfNotPresent
 		}
-		engineType := engine.GetConfiguredType(enginePullFlags.engineType)
+		engineType := engine.GetConfiguredTypeWithVersion(enginePullFlags.engineType, enginePullFlags.engineVersion)
 		version := engine.GetConfiguredVersion(engineType, enginePullFlags.engineVersion, pullPolicy != engine.PullAlways)
 		pull(version, engineType, pullPolicy)
 	},
@@ -58,7 +58,7 @@ func pull(version string, engineType engine.EngineType, pullPolicy engine.PullPo
 
 func init() {
 	enginePullCmd.Flags().StringVarP(&enginePullFlags.engineType, "engine-type", "t", "", "Imposter engine type (valid: docker,native,jvm - default \"docker\")")
-	enginePullCmd.Flags().StringVarP(&enginePullFlags.engineVersion, "version", "v", "", "Imposter engine version (default \"latest\")")
+	enginePullCmd.Flags().StringVarP(&enginePullFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
 	enginePullCmd.Flags().BoolVarP(&enginePullFlags.forcePull, "force", "f", false, "Force engine pull")
 	registerEngineTypeCompletions(enginePullCmd)
 	engineCmd.AddCommand(enginePullCmd)

--- a/cmd/engine_pull.go
+++ b/cmd/engine_pull.go
@@ -58,7 +58,7 @@ func pull(version string, engineType engine.EngineType, pullPolicy engine.PullPo
 
 func init() {
 	enginePullCmd.Flags().StringVarP(&enginePullFlags.engineType, "engine-type", "t", "", "Imposter engine type (valid: docker,native,jvm - default \"docker\")")
-	enginePullCmd.Flags().StringVarP(&enginePullFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
+	enginePullCmd.Flags().StringVarP(&enginePullFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"4\" or \"5\" (latest of that engine line) or \"latest\" (default \"latest\")")
 	enginePullCmd.Flags().BoolVarP(&enginePullFlags.forcePull, "force", "f", false, "Force engine pull")
 	registerEngineTypeCompletions(enginePullCmd)
 	engineCmd.AddCommand(enginePullCmd)

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -52,7 +52,7 @@ Example 2: Install all plugins in config file
 }
 
 func init() {
-	pluginInstallCmd.Flags().StringVarP(&pluginInstallFlags.engineVersion, "version", "v", "", "Imposter engine version (default \"latest\")")
+	pluginInstallCmd.Flags().StringVarP(&pluginInstallFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
 	pluginInstallCmd.Flags().BoolVarP(&pluginInstallFlags.saveDefault, "save-default", "d", false, "Whether to save the plugin as a default")
 	pluginCmd.AddCommand(pluginInstallCmd)
 }

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -52,7 +52,7 @@ Example 2: Install all plugins in config file
 }
 
 func init() {
-	pluginInstallCmd.Flags().StringVarP(&pluginInstallFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
+	pluginInstallCmd.Flags().StringVarP(&pluginInstallFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"4\" or \"5\" (latest of that engine line) or \"latest\" (default \"latest\")")
 	pluginInstallCmd.Flags().BoolVarP(&pluginInstallFlags.saveDefault, "save-default", "d", false, "Whether to save the plugin as a default")
 	pluginCmd.AddCommand(pluginInstallCmd)
 }

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -45,7 +45,7 @@ Example 2: Install all plugins in config file
 	imposter plugin install`,
 	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		engineType := engine.GetConfiguredType(pluginFlags.engineType)
+		engineType := engine.GetConfiguredTypeWithVersion(pluginFlags.engineType, pluginInstallFlags.engineVersion)
 		version := engine.GetConfiguredVersion(engineType, pluginInstallFlags.engineVersion, true)
 		installPlugins(args, engineType, version, pluginInstallFlags.saveDefault)
 	},

--- a/cmd/plugin_uninstall.go
+++ b/cmd/plugin_uninstall.go
@@ -56,7 +56,7 @@ Example 3: Uninstall plugin and remove from defaults
 }
 
 func init() {
-	pluginUninstallCmd.Flags().StringVarP(&pluginUninstallFlags.engineVersion, "version", "v", "", "Imposter engine version (default \"latest\")")
+	pluginUninstallCmd.Flags().StringVarP(&pluginUninstallFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
 	pluginUninstallCmd.Flags().BoolVarP(&pluginUninstallFlags.removeDefault, "remove-default", "d", false, "Whether to remove the plugin from defaults")
 	pluginCmd.AddCommand(pluginUninstallCmd)
 }

--- a/cmd/plugin_uninstall.go
+++ b/cmd/plugin_uninstall.go
@@ -49,7 +49,7 @@ Example 3: Uninstall plugin and remove from defaults
 	imposter plugin uninstall store-redis --remove-default`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		engineType := engine.GetConfiguredType(pluginFlags.engineType)
+		engineType := engine.GetConfiguredTypeWithVersion(pluginFlags.engineType, pluginUninstallFlags.engineVersion)
 		version := engine.GetConfiguredVersion(engineType, pluginUninstallFlags.engineVersion, true)
 		uninstallPlugins(args, engineType, version, pluginUninstallFlags.removeDefault)
 	},

--- a/cmd/plugin_uninstall.go
+++ b/cmd/plugin_uninstall.go
@@ -56,7 +56,7 @@ Example 3: Uninstall plugin and remove from defaults
 }
 
 func init() {
-	pluginUninstallCmd.Flags().StringVarP(&pluginUninstallFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
+	pluginUninstallCmd.Flags().StringVarP(&pluginUninstallFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"4\" or \"5\" (latest of that engine line) or \"latest\" (default \"latest\")")
 	pluginUninstallCmd.Flags().BoolVarP(&pluginUninstallFlags.removeDefault, "remove-default", "d", false, "Whether to remove the plugin from defaults")
 	pluginCmd.AddCommand(pluginUninstallCmd)
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -170,7 +170,7 @@ func applyDetachOptions(startOptions *engine.StartOptions, engineType engine.Eng
 
 func init() {
 	upCmd.Flags().StringVarP(&upFlags.engineType, "engine-type", "t", "", "Imposter engine type (valid: docker,native,jvm - default \"docker\")")
-	upCmd.Flags().StringVarP(&upFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
+	upCmd.Flags().StringVarP(&upFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"4\" or \"5\" (latest of that engine line) or \"latest\" (default \"latest\")")
 	upCmd.Flags().IntVarP(&upFlags.port, "port", "p", 8080, "Port on which to listen")
 	upCmd.Flags().BoolVar(&upFlags.forcePull, "pull", false, "Force engine pull")
 	upCmd.Flags().BoolVar(&upFlags.restartOnChange, "auto-restart", true, "Automatically restart when config dir contents change")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -170,7 +170,7 @@ func applyDetachOptions(startOptions *engine.StartOptions, engineType engine.Eng
 
 func init() {
 	upCmd.Flags().StringVarP(&upFlags.engineType, "engine-type", "t", "", "Imposter engine type (valid: docker,native,jvm - default \"docker\")")
-	upCmd.Flags().StringVarP(&upFlags.engineVersion, "version", "v", "", "Imposter engine version (default \"latest\")")
+	upCmd.Flags().StringVarP(&upFlags.engineVersion, "version", "v", "", "Imposter engine version, e.g. \"5.21.3\", \"5\" (highest v5 release) or \"latest\" (default \"latest\")")
 	upCmd.Flags().IntVarP(&upFlags.port, "port", "p", 8080, "Port on which to listen")
 	upCmd.Flags().BoolVar(&upFlags.forcePull, "pull", false, "Force engine pull")
 	upCmd.Flags().BoolVar(&upFlags.restartOnChange, "auto-restart", true, "Automatically restart when config dir contents change")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -75,12 +75,20 @@ func describeVersions(engineType engine.EngineType, full bool, format outputForm
 		if len(engines) == 0 {
 			props["imposter-engine"] = "none"
 		} else {
+			// prefer a locally installed engine matching the configured
+			// alias over hitting the releases API
 			engineConfigVersion := engine.GetConfiguredVersionOrResolve(engineType, "", true, false)
-			if engineConfigVersion == "latest" {
+			if engineConfigVersion == engine.VersionLatest {
 				engineConfigVersion = engine.GetHighestVersion(engines)
+			} else if major, ok := engine.ParseMajorAlias(engineConfigVersion); ok {
+				engineConfigVersion = engine.GetHighestVersionForMajor(engines, major)
 			}
-			props["imposter-engine"] = engineConfigVersion
-			props["engine-output"] = getInstalledEngineVersion(engineType, engineConfigVersion)
+			if engineConfigVersion == "" {
+				props["imposter-engine"] = "none"
+			} else {
+				props["imposter-engine"] = engineConfigVersion
+				props["engine-output"] = getInstalledEngineVersion(engineType, engineConfigVersion)
+			}
 		}
 	}
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -25,6 +25,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// provideEngine ensures the given engine version is present in the local cache.
+func provideEngine(t *testing.T, engineType engine.EngineType, version string) {
+	t.Helper()
+	provider := engine.GetLibrary(engineType).GetProvider(version)
+	if err := provider.Provide(engine.PullIfNotPresent); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func Test_describeVersions(t *testing.T) {
 	type args struct {
 		engineType engine.EngineType
@@ -73,6 +82,15 @@ func Test_describeVersions(t *testing.T) {
 			},
 		},
 		{
+			name: "print major alias version (native)",
+			args: args{
+				engineType: engine.EngineTypeNative,
+				version:    "5",
+				full:       true,
+				format:     outputFormatPlain,
+			},
+		},
+		{
 			name: "print explicit version in JSON format",
 			args: args{
 				engineType: engine.EngineTypeDockerCore,
@@ -96,18 +114,31 @@ func Test_describeVersions(t *testing.T) {
 			viper.Set("version", tt.args.version)
 
 			var expectedVersion string
-			if tt.args.version == "latest" {
+			major, isAlias := engine.ParseMajorAlias(tt.args.version)
+			switch {
+			case tt.args.version == "latest":
 				latestVersion, err := engine.ResolveLatestToVersion(tt.args.engineType, true)
 				if err != nil {
 					t.Fatal(err)
 				}
-				library := engine.GetLibrary(tt.args.engineType)
-				provider := library.GetProvider(latestVersion)
-				if err := provider.Provide(engine.PullIfNotPresent); err != nil {
+				provideEngine(t, tt.args.engineType, latestVersion)
+				expectedVersion = latestVersion
+
+			case isAlias:
+				// a major alias reports the highest installed engine with that
+				// major version, so ensure the latest of that line is installed
+				aliasVersion, err := engine.ResolveMajorToVersion(major, true)
+				if err != nil {
 					t.Fatal(err)
 				}
-				expectedVersion = latestVersion
-			} else {
+				provideEngine(t, tt.args.engineType, aliasVersion)
+				engines, err := engine.GetLibrary(tt.args.engineType).List()
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedVersion = engine.GetHighestVersionForMajor(engines, major)
+
+			default:
 				expectedVersion = tt.args.version
 			}
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,9 +44,8 @@ The currently supported elements are as follows:
 engine: "docker"
 
 # the engine version - valid values are "latest", a binary release such as "5.21.3",
-# or a major version alias such as "5", meaning the highest release of that major version
-# a major version alias also selects the engine line: "5" and above use the native engine,
-# "4" and below use the JVM engine
+# or the shorthand "4" or "5", meaning the latest release of that engine line
+# ("5" is the native engine, "4" is the JVM engine)
 # see: https://github.com/imposter-project/imposter-go/releases
 # and: https://github.com/imposter-project/imposter-jvm-engine/releases
 version: "latest"

--- a/docs/config.md
+++ b/docs/config.md
@@ -43,8 +43,12 @@ The currently supported elements are as follows:
 # (the legacy value "golang" is still accepted as an alias for "native")
 engine: "docker"
 
-# the engine version - valid values are "latest", or a binary release such as "2.0.1"
-# see: https://github.com/imposter-project/imposter-jvm-engine/releases
+# the engine version - valid values are "latest", a binary release such as "5.21.3",
+# or a major version alias such as "5", meaning the highest release of that major version
+# a major version alias also selects the engine line: "5" and above use the native engine,
+# "4" and below use the JVM engine
+# see: https://github.com/imposter-project/imposter-go/releases
+# and: https://github.com/imposter-project/imposter-jvm-engine/releases
 version: "latest"
 
 # Docker engine specific configuration

--- a/docs/engine_jvm.md
+++ b/docs/engine_jvm.md
@@ -43,3 +43,13 @@ Example:
 Or:
 
     imposter up -t jvm
+
+### Engine version
+
+The JVM engine is version 4 and below. Passing `--version 4` (or `-v 4`) runs the latest JVM engine release:
+
+    imposter up -t jvm -v 4
+
+To pin an exact release, pass it in full:
+
+    imposter up -t jvm -v 4.9.3

--- a/docs/engine_native.md
+++ b/docs/engine_native.md
@@ -56,6 +56,16 @@ Or:
 
     imposter up -t native
 
+### Engine version
+
+The native engine is version 5 and above. Passing `--version 5` (or `-v 5`) runs the latest native engine release, and selects the native engine type if you haven't configured one:
+
+    imposter up -v 5
+
+To pin an exact release, pass it in full:
+
+    imposter up -v 5.21.3
+
 ## Differences from the JVM engine
 
 - **No Groovy scripting** - use JavaScript instead

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -15,7 +15,7 @@ There are a few key concepts to learn before using the SDK:
 
 - **configuration directory**: a directory containing a valid Imposter [configuration](https://docs.imposter.sh/configuration/)
 - **engine type**: this can be `docker`, `jvm` or `native` - see [Docker Engine](./engine_docker.md), [JVM Engine](./engine_jvm.md) or [Native Engine](./engine_native.md)
-- **engine version**: this is the version of Imposter - see [Releases](https://github.com/imposter-project/imposter-jvm-engine/releases)
+- **engine version**: this is the version of Imposter, given as `latest` or an exact release such as `5.21.3` - see releases for the [native engine](https://github.com/imposter-project/imposter-go/releases) (version 5 and above) or the [JVM engine](https://github.com/imposter-project/imposter-jvm-engine/releases) (version 4 and below)
 
 ## Getting started
 

--- a/internal/engine/builder.go
+++ b/internal/engine/builder.go
@@ -159,8 +159,9 @@ func getConfiguredType(typeOverride string, versionOverride string, defaultType 
 	}
 	// No explicit engine type configured. If the user has pinned a specific
 	// engine version we can sometimes derive the engine type from it (e.g.
-	// 5.x implies the native engine). "latest" intentionally does not derive
-	// — callers keep the supplied default until "latest" is re-pointed at v5.
+	// 5.x, or the bare "5" alias, implies the native engine). "latest"
+	// intentionally does not derive — callers keep the supplied default
+	// until "latest" is re-pointed at v5.
 	version := stringutil.GetFirstNonEmpty(versionOverride, viper.GetString("version"))
 	if derived := DeriveEngineTypeFromVersion(version); derived != EngineTypeNone {
 		return derived
@@ -172,18 +173,31 @@ func GetConfiguredVersion(engineType EngineType, override string, allowCached bo
 	return GetConfiguredVersionOrResolve(engineType, override, allowCached, true)
 }
 
-func GetConfiguredVersionOrResolve(engineType EngineType, override string, allowCached bool, resolveIfLatest bool) string {
+// GetConfiguredVersionOrResolve returns the configured engine version. If
+// resolveAliases is set, version aliases - "latest", or a bare major version
+// such as "4" or "5" - are resolved to the concrete release they denote.
+func GetConfiguredVersionOrResolve(engineType EngineType, override string, allowCached bool, resolveAliases bool) string {
 	version := stringutil.GetFirstNonEmpty(
 		override,
 		viper.GetString("version"),
-		"latest",
+		VersionLatest,
 	)
-	if version == "latest" && resolveIfLatest {
+	if !resolveAliases {
+		return version
+	}
+	if version == VersionLatest {
 		latest, err := ResolveLatestToVersion(engineType, allowCached)
 		if err != nil {
 			panic(err)
 		}
-		version = latest
+		return latest
+	}
+	if major, ok := ParseMajorAlias(version); ok {
+		resolved, err := ResolveMajorToVersion(major, allowCached)
+		if err != nil {
+			panic(err)
+		}
+		return resolved
 	}
 	return version
 }

--- a/internal/engine/builder_test.go
+++ b/internal/engine/builder_test.go
@@ -36,6 +36,27 @@ func TestGetConfiguredVersion(t *testing.T) {
 	}
 }
 
+func TestGetConfiguredVersionUnresolved(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		want     string
+	}{
+		{name: "latest alias left unresolved", override: "latest", want: "latest"},
+		{name: "major alias left unresolved", override: "5", want: "5"},
+		{name: "no version defaults to latest alias", override: "", want: "latest"},
+		{name: "explicit version returned as-is", override: "5.21.3", want: "5.21.3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetConfiguredVersionOrResolve(EngineTypeDockerCore, tt.override, false, false)
+			if got != tt.want {
+				t.Errorf("GetConfiguredVersionOrResolve() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetConfiguredType(t *testing.T) {
 	type args struct {
 		override string
@@ -84,6 +105,9 @@ func TestGetConfiguredTypeWithVersion(t *testing.T) {
 		{name: "5.x version override derives native", args: args{versionOverride: "5.0.0"}, want: EngineTypeNative},
 		{name: "5.x configured version derives native", configureVersion: "5.2.3", want: EngineTypeNative},
 		{name: "4.x version keeps default", args: args{versionOverride: "4.9.0"}, want: defaultEngineType},
+		{name: "major alias 5 derives native", args: args{versionOverride: "5"}, want: EngineTypeNative},
+		{name: "configured major alias 5 derives native", configureVersion: "5", want: EngineTypeNative},
+		{name: "major alias 4 keeps default", args: args{versionOverride: "4"}, want: defaultEngineType},
 		{name: "latest keeps default", args: args{versionOverride: "latest"}, want: defaultEngineType},
 		{name: "no version, no type, returns default", want: defaultEngineType},
 	}

--- a/internal/engine/meta.go
+++ b/internal/engine/meta.go
@@ -11,10 +11,9 @@ func getRepoNameForEngineType(engineType EngineType) string {
 }
 
 // getRepoNameForMajor returns the GitHub repository name releasing the given
-// major version of the engine. Major version 5 onwards is the native engine;
-// earlier majors are the JVM engine. This is independent of the configured
-// engine type, as some engine types (such as awslambda) are built from both
-// repositories.
+// major version of the engine: 5 is the native engine and 4 is the JVM engine.
+// This is independent of the configured engine type, as some engine types
+// (such as awslambda) are built from both repositories.
 func getRepoNameForMajor(major int64) string {
 	if major >= 5 {
 		return "imposter-go"

--- a/internal/engine/meta.go
+++ b/internal/engine/meta.go
@@ -9,3 +9,15 @@ func getRepoNameForEngineType(engineType EngineType) string {
 		return "imposter-jvm-engine"
 	}
 }
+
+// getRepoNameForMajor returns the GitHub repository name releasing the given
+// major version of the engine. Major version 5 onwards is the native engine;
+// earlier majors are the JVM engine. This is independent of the configured
+// engine type, as some engine types (such as awslambda) are built from both
+// repositories.
+func getRepoNameForMajor(major int64) string {
+	if major >= 5 {
+		return "imposter-go"
+	}
+	return "imposter-jvm-engine"
+}

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -7,26 +7,28 @@ import (
 	"github.com/imposter-project/imposter-cli/internal/prefs"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 )
 
 const latestReleaseApi = "https://api.github.com/repos/imposter-project/%s/releases/latest"
-const releaseListApi = "https://api.github.com/repos/imposter-project/%s/releases?per_page=100&page=%d"
 const checkThresholdSeconds = 86_400
-
-// maxReleaseListPages bounds how far back through the release list a
-// major-version alias lookup will page before giving up.
-const maxReleaseListPages = 5
 
 // VersionLatest is the alias meaning "the newest release of the engine".
 const VersionLatest = "latest"
 
+// majorAliases are the supported short version aliases, each meaning "the
+// newest release of that engine line": "4" is the JVM engine and "5" is the
+// native engine.
+var majorAliases = map[string]int64{
+	"4": 4,
+	"5": 5,
+}
+
 func ResolveLatestToVersion(engineType EngineType, allowCached bool) (string, error) {
 	logger.Tracef("resolving latest version (cache allowed: %v)", allowCached)
 
-	latest, err := resolveAlias(string(engineType), VersionLatest, allowCached, func() (string, error) {
+	latest, err := resolveLatest(string(engineType), allowCached, func() (string, error) {
 		return fetchLatestFromApi(fmt.Sprintf(latestReleaseApi, getRepoNameForEngineType(engineType)))
 	})
 	if err != nil {
@@ -37,16 +39,17 @@ func ResolveLatestToVersion(engineType EngineType, allowCached bool) (string, er
 	return latest, nil
 }
 
-// ResolveMajorToVersion resolves a bare major-version alias, such as "4", to
-// the highest release carrying that major version, such as "4.9.3". The major
-// version alone determines which repository is searched, so this does not
-// depend on the configured engine type.
+// ResolveMajorToVersion resolves a major-version alias to the latest release
+// of the corresponding engine line, so "4" resolves to the latest JVM engine
+// release and "5" to the latest native engine release. The major version alone
+// determines which repository is used, so this does not depend on the
+// configured engine type.
 func ResolveMajorToVersion(major int64, allowCached bool) (string, error) {
 	logger.Tracef("resolving version alias %d (cache allowed: %v)", major, allowCached)
 
 	repo := getRepoNameForMajor(major)
-	resolved, err := resolveAlias(repo, fmt.Sprintf("v%d", major), allowCached, func() (string, error) {
-		return fetchHighestForMajor(repo, major)
+	resolved, err := resolveLatest(repo, allowCached, func() (string, error) {
+		return fetchLatestFromApi(fmt.Sprintf(latestReleaseApi, repo))
 	})
 	if err != nil {
 		return "", err
@@ -56,15 +59,11 @@ func ResolveMajorToVersion(major int64, allowCached bool) (string, error) {
 	return resolved, nil
 }
 
-// ParseMajorAlias returns the major version denoted by a bare major-version
-// alias, such as "4" or "5", or (0, false) if the given version is not such an
-// alias.
+// ParseMajorAlias returns the major version denoted by a major-version alias,
+// or (0, false) if the given version is not one of the supported aliases.
 func ParseMajorAlias(version string) (int64, bool) {
-	major, err := strconv.ParseInt(version, 10, 64)
-	if err != nil || major < 0 {
-		return 0, false
-	}
-	return major, true
+	major, ok := majorAliases[version]
+	return major, ok
 }
 
 // parseMajorVersion returns the major component of the given engine version,
@@ -150,15 +149,15 @@ func getHighestVersion(engines []EngineMetadata, major *int64) string {
 	return ""
 }
 
-// resolveAlias resolves a version alias, such as "latest" or "v4", to a
-// concrete version, using the cached value if permitted and falling back to it
-// if the lookup fails. The scope namespaces the cache entry - the engine type
-// for "latest", or the repository name for a major version alias.
-func resolveAlias(scope string, alias string, allowCached bool, lookup func() (string, error)) (string, error) {
+// resolveLatest resolves the latest version for the given scope, using the
+// cached value if permitted and falling back to it if the lookup fails. The
+// scope namespaces the cache entry - the engine type when resolving "latest",
+// or the repository name when resolving a major version alias.
+func resolveLatest(scope string, allowCached bool, lookup func() (string, error)) (string, error) {
 	now := time.Now().Unix()
 
 	if allowCached {
-		if cached := loadCached(scope, alias, now); cached != "" {
+		if cached := loadCached(scope, now); cached != "" {
 			return cached, nil
 		}
 	}
@@ -166,54 +165,41 @@ func resolveAlias(scope string, alias string, allowCached bool, lookup func() (s
 	resolved, err := lookup()
 	if err != nil {
 		if !allowCached {
-			return "", fmt.Errorf("failed to fetch version for alias '%s' from API: %s", alias, err)
+			return "", fmt.Errorf("failed to fetch latest version from API: %s", err)
 		}
 
-		logger.Warnf("failed to fetch version for alias '%s' from API (%s) - checking cache", alias, err)
-		cached := loadCached(scope, alias, now)
+		logger.Warnf("failed to fetch latest version from API (%s) - checking cache", err)
+		cached := loadCached(scope, now)
 		if cached == "" {
-			return "", fmt.Errorf("failed to resolve version for alias '%s' (%s) and no cached version found", alias, err)
+			return "", fmt.Errorf("failed to resolve latest version (%s) and no cached version found", err)
 		}
 		// don't persist the cached version back to the prefs store
 		return cached, nil
 	}
 
-	storeCached(scope, alias, resolved, now)
+	storeCached(scope, resolved, now)
 	return resolved, nil
 }
 
-// aliasCacheKeys returns the prefs keys holding the resolved version and the
-// last check time for the given alias. The "latest" alias keeps its original
-// key names so existing prefs files remain valid.
-func aliasCacheKeys(scope string, alias string) (versionKey string, checkKey string) {
-	if alias == VersionLatest {
-		return scope + ".latest", scope + ".last_version_check"
-	}
-	prefix := scope + "." + alias
-	return prefix + ".latest", prefix + ".last_version_check"
-}
-
-func loadCached(scope string, alias string, now int64) string {
+func loadCached(scope string, now int64) string {
 	var version string
 
-	versionKey, checkKey := aliasCacheKeys(scope, alias)
 	p := getVersionPrefs()
-	lastCheck, _ := p.ReadPropertyInt(checkKey)
+	lastCheck, _ := p.ReadPropertyInt(scope + ".last_version_check")
 	if now-int64(lastCheck) < checkThresholdSeconds {
-		version, _ = p.ReadPropertyString(versionKey)
+		version, _ = p.ReadPropertyString(scope + ".latest")
 	}
 
-	logger.Tracef("cached value for alias '%s': %s", alias, version)
+	logger.Tracef("latest version cached value for %s: %s", scope, version)
 	return version
 }
 
-func storeCached(scope string, alias string, version string, now int64) {
-	versionKey, checkKey := aliasCacheKeys(scope, alias)
+func storeCached(scope string, version string, now int64) {
 	p := getVersionPrefs()
-	if err := p.WriteProperty(versionKey, version); err != nil {
-		logger.Warnf("failed to record version for alias '%s': %s", alias, err)
+	if err := p.WriteProperty(scope+".latest", version); err != nil {
+		logger.Warnf("failed to record latest version: %s", err)
 	}
-	if err := p.WriteProperty(checkKey, now); err != nil {
+	if err := p.WriteProperty(scope+".last_version_check", now); err != nil {
 		logger.Warnf("failed to record last version check time: %s", err)
 	}
 }
@@ -242,92 +228,4 @@ func fetchLatestFromApi(apiUrl string) (string, error) {
 	}
 	tagName := data["tag_name"].(string)
 	return strings.TrimPrefix(tagName, "v"), nil
-}
-
-type release struct {
-	TagName    string `json:"tag_name"`
-	Draft      bool   `json:"draft"`
-	Prerelease bool   `json:"prerelease"`
-}
-
-// fetchHighestForMajor returns the highest released version of the given repo
-// carrying the given major version. Draft and pre-release entries are ignored,
-// matching the behaviour of the 'latest release' API used for "latest".
-func fetchHighestForMajor(repo string, major int64) (string, error) {
-	var highest *semver.Version
-
-	for page := 1; page <= maxReleaseListPages; page++ {
-		releases, err := fetchReleasesFromApi(fmt.Sprintf(releaseListApi, repo, page))
-		if err != nil {
-			return "", err
-		}
-		if len(releases) == 0 {
-			break
-		}
-
-		pageHighest, sawOlderMajor := selectHighestForMajor(releases, major)
-		if pageHighest != nil && (highest == nil || highest.LessThan(*pageHighest)) {
-			highest = pageHighest
-		}
-		// releases are returned newest first, so once older majors appear
-		// there is nothing further back worth paging for
-		if sawOlderMajor {
-			break
-		}
-	}
-
-	if highest == nil {
-		return "", fmt.Errorf("no release found for major version %d of %s", major, repo)
-	}
-	return highest.String(), nil
-}
-
-// selectHighestForMajor returns the highest of the given releases carrying the
-// given major version, ignoring drafts, pre-releases and unparseable tags. It
-// also reports whether any release with a lower major version was seen.
-func selectHighestForMajor(releases []release, major int64) (*semver.Version, bool) {
-	var highest *semver.Version
-	var sawOlderMajor bool
-
-	for _, r := range releases {
-		if r.Draft || r.Prerelease {
-			continue
-		}
-		v, err := semver.NewVersion(strings.TrimPrefix(r.TagName, "v"))
-		if err != nil {
-			continue
-		}
-		if v.Major < major {
-			sawOlderMajor = true
-			continue
-		}
-		if v.Major > major {
-			continue
-		}
-		if highest == nil || highest.LessThan(*v) {
-			highest = v
-		}
-	}
-	return highest, sawOlderMajor
-}
-
-func fetchReleasesFromApi(apiUrl string) ([]release, error) {
-	logger.Tracef("fetching releases from: %s", apiUrl)
-	resp, err := http.Get(apiUrl)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list releases from %s: %s", apiUrl, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("failed to list releases from %s - status code: %d", apiUrl, resp.StatusCode)
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list releases from %s - cannot read response body: %s", apiUrl, err)
-	}
-	var releases []release
-	if err := json.Unmarshal(body, &releases); err != nil {
-		return nil, fmt.Errorf("failed to list releases from %s - cannot unmarshall response body: %s", apiUrl, err)
-	}
-	return releases, nil
 }

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -7,39 +7,75 @@ import (
 	"github.com/imposter-project/imposter-cli/internal/prefs"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const latestReleaseApi = "https://api.github.com/repos/imposter-project/%s/releases/latest"
+const releaseListApi = "https://api.github.com/repos/imposter-project/%s/releases?per_page=100&page=%d"
 const checkThresholdSeconds = 86_400
+
+// maxReleaseListPages bounds how far back through the release list a
+// major-version alias lookup will page before giving up.
+const maxReleaseListPages = 5
+
+// VersionLatest is the alias meaning "the newest release of the engine".
+const VersionLatest = "latest"
 
 func ResolveLatestToVersion(engineType EngineType, allowCached bool) (string, error) {
 	logger.Tracef("resolving latest version (cache allowed: %v)", allowCached)
 
-	now := time.Now().Unix()
-	var latest string
-
-	if allowCached {
-		latest = loadCached(engineType, now)
-	}
-
-	if latest == "" {
-		lookup, err := lookupLatest(engineType, now, allowCached)
-		if err != nil {
-			return "", err
-		}
-		latest = lookup
+	latest, err := resolveAlias(string(engineType), VersionLatest, allowCached, func() (string, error) {
+		return fetchLatestFromApi(fmt.Sprintf(latestReleaseApi, getRepoNameForEngineType(engineType)))
+	})
+	if err != nil {
+		return "", err
 	}
 
 	logger.Tracef("resolved latest version: %s", latest)
 	return latest, nil
 }
 
+// ResolveMajorToVersion resolves a bare major-version alias, such as "4", to
+// the highest release carrying that major version, such as "4.9.3". The major
+// version alone determines which repository is searched, so this does not
+// depend on the configured engine type.
+func ResolveMajorToVersion(major int64, allowCached bool) (string, error) {
+	logger.Tracef("resolving version alias %d (cache allowed: %v)", major, allowCached)
+
+	repo := getRepoNameForMajor(major)
+	resolved, err := resolveAlias(repo, fmt.Sprintf("v%d", major), allowCached, func() (string, error) {
+		return fetchHighestForMajor(repo, major)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	logger.Tracef("resolved version alias %d: %s", major, resolved)
+	return resolved, nil
+}
+
+// ParseMajorAlias returns the major version denoted by a bare major-version
+// alias, such as "4" or "5", or (0, false) if the given version is not such an
+// alias.
+func ParseMajorAlias(version string) (int64, bool) {
+	major, err := strconv.ParseInt(version, 10, 64)
+	if err != nil || major < 0 {
+		return 0, false
+	}
+	return major, true
+}
+
 // parseMajorVersion returns the major component of the given engine version,
-// or (0, false) if the version cannot be parsed as semver. Callers decide how
-// to treat the unparseable case (typically: assume the modern 5.x+ line).
+// accepting either a full semver version or a bare major-version alias such as
+// "4". It returns (0, false) if the version can be parsed as neither. Callers
+// decide how to treat the unparseable case (typically: assume the modern 5.x+
+// line).
 func parseMajorVersion(version string) (int64, bool) {
+	if major, ok := ParseMajorAlias(version); ok {
+		return major, true
+	}
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		return 0, false
@@ -65,12 +101,13 @@ func UsesEnvConfig(version string) bool {
 // should fall back to their configured/default engine type when this returns
 // EngineTypeNone.
 //
-// Versions 5.x and later resolve to EngineTypeNative. Earlier versions, the
-// "latest" alias, the empty string, and unparseable values all return
-// EngineTypeNone so the default engine continues to apply. (Future: "latest"
-// will be re-pointed at v5 and so will yield EngineTypeNative.)
+// Versions 5.x and later resolve to EngineTypeNative, including the bare "5"
+// major-version alias. Earlier versions, the "latest" alias, the empty string,
+// and unparseable values all return EngineTypeNone so the default engine
+// continues to apply. (Future: "latest" will be re-pointed at v5 and so will
+// yield EngineTypeNative.)
 func DeriveEngineTypeFromVersion(version string) EngineType {
-	if version == "" || version == "latest" {
+	if version == "" || version == VersionLatest {
 		return EngineTypeNone
 	}
 	major, ok := parseMajorVersion(version)
@@ -84,10 +121,23 @@ func DeriveEngineTypeFromVersion(version string) EngineType {
 }
 
 func GetHighestVersion(engines []EngineMetadata) string {
+	return getHighestVersion(engines, nil)
+}
+
+// GetHighestVersionForMajor returns the highest of the given engine versions
+// carrying the given major version, or the empty string if none do.
+func GetHighestVersionForMajor(engines []EngineMetadata, major int64) string {
+	return getHighestVersion(engines, &major)
+}
+
+func getHighestVersion(engines []EngineMetadata, major *int64) string {
 	var highest *semver.Version
 	for _, engine := range engines {
 		v, err := semver.NewVersion(engine.Version)
 		if err != nil {
+			continue
+		}
+		if major != nil && v.Major != *major {
 			continue
 		}
 		if highest == nil || highest.LessThan(*v) {
@@ -100,47 +150,72 @@ func GetHighestVersion(engines []EngineMetadata) string {
 	return ""
 }
 
-func loadCached(engineType EngineType, now int64) string {
-	var latest string
+// resolveAlias resolves a version alias, such as "latest" or "v4", to a
+// concrete version, using the cached value if permitted and falling back to it
+// if the lookup fails. The scope namespaces the cache entry - the engine type
+// for "latest", or the repository name for a major version alias.
+func resolveAlias(scope string, alias string, allowCached bool, lookup func() (string, error)) (string, error) {
+	now := time.Now().Unix()
 
-	p := getVersionPrefs()
-	lastCheck, _ := p.ReadPropertyInt(string(engineType) + ".last_version_check")
-	if now-int64(lastCheck) < checkThresholdSeconds {
-		latest, _ = p.ReadPropertyString(string(engineType) + ".latest")
+	if allowCached {
+		if cached := loadCached(scope, alias, now); cached != "" {
+			return cached, nil
+		}
 	}
 
-	logger.Tracef("latest version cached value: %s", latest)
-	return latest
+	resolved, err := lookup()
+	if err != nil {
+		if !allowCached {
+			return "", fmt.Errorf("failed to fetch version for alias '%s' from API: %s", alias, err)
+		}
+
+		logger.Warnf("failed to fetch version for alias '%s' from API (%s) - checking cache", alias, err)
+		cached := loadCached(scope, alias, now)
+		if cached == "" {
+			return "", fmt.Errorf("failed to resolve version for alias '%s' (%s) and no cached version found", alias, err)
+		}
+		// don't persist the cached version back to the prefs store
+		return cached, nil
+	}
+
+	storeCached(scope, alias, resolved, now)
+	return resolved, nil
 }
 
-func lookupLatest(engineType EngineType, now int64, allowFallbackToCached bool) (string, error) {
-	apiUrl := fmt.Sprintf(latestReleaseApi, getRepoNameForEngineType(engineType))
-	latest, err := fetchLatestFromApi(apiUrl)
-	if err != nil {
-		if !allowFallbackToCached {
-			return "", fmt.Errorf("failed to fetch latest version from API: %s", err)
-		}
-
-		logger.Warnf("failed to fetch latest version from API (%s) - checking cache", err)
-		latest = loadCached(engineType, now)
-		if latest == "" {
-			return "", fmt.Errorf("failed to resolve latest version (%s) and no cached version found", err)
-		} else {
-			// don't persist the cached version back to the prefs store
-			return latest, nil
-		}
+// aliasCacheKeys returns the prefs keys holding the resolved version and the
+// last check time for the given alias. The "latest" alias keeps its original
+// key names so existing prefs files remain valid.
+func aliasCacheKeys(scope string, alias string) (versionKey string, checkKey string) {
+	if alias == VersionLatest {
+		return scope + ".latest", scope + ".last_version_check"
 	}
+	prefix := scope + "." + alias
+	return prefix + ".latest", prefix + ".last_version_check"
+}
 
+func loadCached(scope string, alias string, now int64) string {
+	var version string
+
+	versionKey, checkKey := aliasCacheKeys(scope, alias)
 	p := getVersionPrefs()
-	err = p.WriteProperty(string(engineType)+".latest", latest)
-	if err != nil {
-		logger.Warnf("failed to record latest version: %s", err)
+	lastCheck, _ := p.ReadPropertyInt(checkKey)
+	if now-int64(lastCheck) < checkThresholdSeconds {
+		version, _ = p.ReadPropertyString(versionKey)
 	}
-	err = p.WriteProperty(string(engineType)+".last_version_check", now)
-	if err != nil {
+
+	logger.Tracef("cached value for alias '%s': %s", alias, version)
+	return version
+}
+
+func storeCached(scope string, alias string, version string, now int64) {
+	versionKey, checkKey := aliasCacheKeys(scope, alias)
+	p := getVersionPrefs()
+	if err := p.WriteProperty(versionKey, version); err != nil {
+		logger.Warnf("failed to record version for alias '%s': %s", alias, err)
+	}
+	if err := p.WriteProperty(checkKey, now); err != nil {
 		logger.Warnf("failed to record last version check time: %s", err)
 	}
-	return latest, nil
 }
 
 func getVersionPrefs() prefs.Prefs {
@@ -167,4 +242,92 @@ func fetchLatestFromApi(apiUrl string) (string, error) {
 	}
 	tagName := data["tag_name"].(string)
 	return strings.TrimPrefix(tagName, "v"), nil
+}
+
+type release struct {
+	TagName    string `json:"tag_name"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// fetchHighestForMajor returns the highest released version of the given repo
+// carrying the given major version. Draft and pre-release entries are ignored,
+// matching the behaviour of the 'latest release' API used for "latest".
+func fetchHighestForMajor(repo string, major int64) (string, error) {
+	var highest *semver.Version
+
+	for page := 1; page <= maxReleaseListPages; page++ {
+		releases, err := fetchReleasesFromApi(fmt.Sprintf(releaseListApi, repo, page))
+		if err != nil {
+			return "", err
+		}
+		if len(releases) == 0 {
+			break
+		}
+
+		pageHighest, sawOlderMajor := selectHighestForMajor(releases, major)
+		if pageHighest != nil && (highest == nil || highest.LessThan(*pageHighest)) {
+			highest = pageHighest
+		}
+		// releases are returned newest first, so once older majors appear
+		// there is nothing further back worth paging for
+		if sawOlderMajor {
+			break
+		}
+	}
+
+	if highest == nil {
+		return "", fmt.Errorf("no release found for major version %d of %s", major, repo)
+	}
+	return highest.String(), nil
+}
+
+// selectHighestForMajor returns the highest of the given releases carrying the
+// given major version, ignoring drafts, pre-releases and unparseable tags. It
+// also reports whether any release with a lower major version was seen.
+func selectHighestForMajor(releases []release, major int64) (*semver.Version, bool) {
+	var highest *semver.Version
+	var sawOlderMajor bool
+
+	for _, r := range releases {
+		if r.Draft || r.Prerelease {
+			continue
+		}
+		v, err := semver.NewVersion(strings.TrimPrefix(r.TagName, "v"))
+		if err != nil {
+			continue
+		}
+		if v.Major < major {
+			sawOlderMajor = true
+			continue
+		}
+		if v.Major > major {
+			continue
+		}
+		if highest == nil || highest.LessThan(*v) {
+			highest = v
+		}
+	}
+	return highest, sawOlderMajor
+}
+
+func fetchReleasesFromApi(apiUrl string) ([]release, error) {
+	logger.Tracef("fetching releases from: %s", apiUrl)
+	resp, err := http.Get(apiUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list releases from %s: %s", apiUrl, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("failed to list releases from %s - status code: %d", apiUrl, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list releases from %s - cannot read response body: %s", apiUrl, err)
+	}
+	var releases []release
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, fmt.Errorf("failed to list releases from %s - cannot unmarshall response body: %s", apiUrl, err)
+	}
+	return releases, nil
 }

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -226,6 +226,9 @@ func fetchLatestFromApi(apiUrl string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to determine latest version from %s - cannot unmarshall response body: %s", apiUrl, err)
 	}
-	tagName := data["tag_name"].(string)
+	tagName, ok := data["tag_name"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed to determine latest version from %s - no tag name in response body", apiUrl)
+	}
 	return strings.TrimPrefix(tagName, "v"), nil
 }

--- a/internal/engine/version_resolve_test.go
+++ b/internal/engine/version_resolve_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright © 2021 Pete Cornish <outofcoffee@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// useTempPrefs points the prefs store at a temporary directory, so version
+// cache reads and writes do not touch the user's own prefs file.
+func useTempPrefs(t *testing.T) {
+	t.Helper()
+	viper.Set("prefs.dir", t.TempDir())
+	t.Cleanup(func() {
+		viper.Set("prefs.dir", nil)
+	})
+}
+
+// countingLookup returns a lookup function yielding the given version, along
+// with a pointer to the number of times it was invoked.
+func countingLookup(version string) (func() (string, error), *int) {
+	var calls int
+	return func() (string, error) {
+		calls++
+		return version, nil
+	}, &calls
+}
+
+func TestResolveLatestUsesFreshCache(t *testing.T) {
+	useTempPrefs(t)
+	storeCached("docker", "4.9.3", time.Now().Unix())
+
+	lookup, calls := countingLookup("9.9.9")
+	got, err := resolveLatest("docker", true, lookup)
+	if err != nil {
+		t.Fatalf("resolveLatest() error = %v", err)
+	}
+	if got != "4.9.3" {
+		t.Errorf("resolveLatest() = %q, want cached %q", got, "4.9.3")
+	}
+	if *calls != 0 {
+		t.Errorf("lookup called %d times, want 0 when a fresh cached value exists", *calls)
+	}
+}
+
+func TestResolveLatestIgnoresStaleCache(t *testing.T) {
+	useTempPrefs(t)
+	stale := time.Now().Unix() - checkThresholdSeconds - 1
+	storeCached("docker", "4.9.3", stale)
+
+	lookup, calls := countingLookup("4.9.4")
+	got, err := resolveLatest("docker", true, lookup)
+	if err != nil {
+		t.Fatalf("resolveLatest() error = %v", err)
+	}
+	if got != "4.9.4" {
+		t.Errorf("resolveLatest() = %q, want looked up %q", got, "4.9.4")
+	}
+	if *calls != 1 {
+		t.Errorf("lookup called %d times, want 1 when the cached value is stale", *calls)
+	}
+
+	// the newly resolved version should have been cached
+	if cached := loadCached("docker", time.Now().Unix()); cached != "4.9.4" {
+		t.Errorf("cached value = %q, want %q", cached, "4.9.4")
+	}
+}
+
+func TestResolveLatestSkipsCacheWhenNotAllowed(t *testing.T) {
+	useTempPrefs(t)
+	storeCached("docker", "4.9.3", time.Now().Unix())
+
+	lookup, calls := countingLookup("4.9.4")
+	got, err := resolveLatest("docker", false, lookup)
+	if err != nil {
+		t.Fatalf("resolveLatest() error = %v", err)
+	}
+	if got != "4.9.4" {
+		t.Errorf("resolveLatest() = %q, want looked up %q", got, "4.9.4")
+	}
+	if *calls != 1 {
+		t.Errorf("lookup called %d times, want 1 when the cache is not allowed", *calls)
+	}
+}
+
+func TestResolveLatestErrorsWhenLookupFails(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowCached bool
+		wantErr     string
+	}{
+		{name: "cache not allowed", allowCached: false, wantErr: "failed to fetch latest version from API"},
+		{name: "cache allowed but empty", allowCached: true, wantErr: "no cached version found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useTempPrefs(t)
+
+			_, err := resolveLatest("docker", tt.allowCached, func() (string, error) {
+				return "", fmt.Errorf("simulated API failure")
+			})
+			if err == nil {
+				t.Fatal("resolveLatest() error = nil, want an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("resolveLatest() error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestResolveLatestScopesCache checks that each scope keeps its own cached
+// version, so a version alias resolved against one repository cannot return
+// the version cached for another.
+func TestResolveLatestScopesCache(t *testing.T) {
+	useTempPrefs(t)
+	now := time.Now().Unix()
+	storeCached("imposter-jvm-engine", "4.9.3", now)
+	storeCached("imposter-go", "5.21.3", now)
+	storeCached("docker", "4.9.1", now)
+
+	tests := []struct {
+		scope string
+		want  string
+	}{
+		{scope: "imposter-jvm-engine", want: "4.9.3"},
+		{scope: "imposter-go", want: "5.21.3"},
+		{scope: "docker", want: "4.9.1"},
+		{scope: "native", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scope, func(t *testing.T) {
+			if got := loadCached(tt.scope, now); got != tt.want {
+				t.Errorf("loadCached(%q) = %q, want %q", tt.scope, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetConfiguredVersionResolvesAliases checks alias resolution end to end,
+// priming the version cache so no API call is made. The repository a major
+// alias resolves against is determined by the alias, not the engine type.
+func TestGetConfiguredVersionResolvesAliases(t *testing.T) {
+	tests := []struct {
+		name       string
+		engineType EngineType
+		override   string
+		want       string
+	}{
+		{name: "alias 5 resolves against the native repo", engineType: EngineTypeDockerCore, override: "5", want: "5.21.3"},
+		{name: "alias 5 resolves against the native repo for lambda", engineType: EngineTypeAwsLambda, override: "5", want: "5.21.3"},
+		{name: "alias 4 resolves against the jvm repo", engineType: EngineTypeNative, override: "4", want: "4.9.3"},
+		{name: "latest resolves against the engine type", engineType: EngineTypeDockerCore, override: "latest", want: "4.9.1"},
+		{name: "explicit version is not resolved", engineType: EngineTypeDockerCore, override: "4.8.0", want: "4.8.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			useTempPrefs(t)
+			now := time.Now().Unix()
+			storeCached("imposter-jvm-engine", "4.9.3", now)
+			storeCached("imposter-go", "5.21.3", now)
+			storeCached(string(EngineTypeDockerCore), "4.9.1", now)
+
+			if got := GetConfiguredVersion(tt.engineType, tt.override, true); got != tt.want {
+				t.Errorf("GetConfiguredVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRepoNameForMajor(t *testing.T) {
+	tests := []struct {
+		major int64
+		want  string
+	}{
+		{major: 4, want: "imposter-jvm-engine"},
+		{major: 5, want: "imposter-go"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("v%d", tt.major), func(t *testing.T) {
+			if got := getRepoNameForMajor(tt.major); got != tt.want {
+				t.Errorf("getRepoNameForMajor(%d) = %q, want %q", tt.major, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRepoNameForEngineType(t *testing.T) {
+	tests := []struct {
+		engineType EngineType
+		want       string
+	}{
+		{engineType: EngineTypeNative, want: "imposter-go"},
+		{engineType: EngineTypeDockerCore, want: "imposter-jvm-engine"},
+		{engineType: EngineTypeJvmSingleJar, want: "imposter-jvm-engine"},
+		{engineType: EngineTypeAwsLambda, want: "imposter-jvm-engine"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.engineType), func(t *testing.T) {
+			if got := getRepoNameForEngineType(tt.engineType); got != tt.want {
+				t.Errorf("getRepoNameForEngineType(%q) = %q, want %q", tt.engineType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchLatestFromApi(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       string
+		wantErr    string
+	}{
+		{name: "tag name with v prefix", statusCode: http.StatusOK, body: `{"tag_name":"v5.21.3"}`, want: "5.21.3"},
+		{name: "tag name without v prefix", statusCode: http.StatusOK, body: `{"tag_name":"5.21.3"}`, want: "5.21.3"},
+		{name: "error status code", statusCode: http.StatusNotFound, body: `{}`, wantErr: "status code: 404"},
+		{name: "unparseable body", statusCode: http.StatusOK, body: `not json`, wantErr: "cannot unmarshall response body"},
+		{name: "missing tag name", statusCode: http.StatusOK, body: `{}`, wantErr: "no tag name in response body"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			got, err := fetchLatestFromApi(server.URL)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("fetchLatestFromApi() error = nil, want it to contain %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("fetchLatestFromApi() error = %q, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fetchLatestFromApi() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("fetchLatestFromApi() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/engine/version_test.go
+++ b/internal/engine/version_test.go
@@ -57,10 +57,9 @@ func TestDeriveEngineTypeFromVersion(t *testing.T) {
 		{name: "5.x derives native", version: "5.2.3", want: EngineTypeNative},
 		{name: "6.x derives native", version: "6.0.0", want: EngineTypeNative},
 		{name: "5.x pre-release derives native", version: "5.0.0-beta.1", want: EngineTypeNative},
-		{name: "major alias 3 has no derivation", version: "3", want: EngineTypeNone},
 		{name: "major alias 4 has no derivation", version: "4", want: EngineTypeNone},
 		{name: "major alias 5 derives native", version: "5", want: EngineTypeNative},
-		{name: "major alias 6 derives native", version: "6", want: EngineTypeNative},
+		{name: "unsupported bare major keeps default", version: "6", want: EngineTypeNone},
 		{name: "latest keeps default", version: "latest", want: EngineTypeNone},
 		{name: "empty keeps default", version: "", want: EngineTypeNone},
 		{name: "unparseable keeps default", version: "dev", want: EngineTypeNone},
@@ -81,60 +80,21 @@ func TestParseMajorAlias(t *testing.T) {
 		want    int64
 		wantOk  bool
 	}{
-		{name: "bare major", version: "4", want: 4, wantOk: true},
-		{name: "bare major 5", version: "5", want: 5, wantOk: true},
-		{name: "multi-digit major", version: "10", want: 10, wantOk: true},
+		{name: "jvm alias", version: "4", want: 4, wantOk: true},
+		{name: "native alias", version: "5", want: 5, wantOk: true},
+		{name: "unsupported older major is not an alias", version: "3", wantOk: false},
+		{name: "unsupported newer major is not an alias", version: "6", wantOk: false},
 		{name: "full version is not an alias", version: "4.9.3", wantOk: false},
 		{name: "partial version is not an alias", version: "4.9", wantOk: false},
 		{name: "latest is not a major alias", version: "latest", wantOk: false},
 		{name: "empty is not an alias", version: "", wantOk: false},
 		{name: "prefixed major is not an alias", version: "v5", wantOk: false},
-		{name: "negative is not an alias", version: "-5", wantOk: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotOk := ParseMajorAlias(tt.version)
 			if gotOk != tt.wantOk || (gotOk && got != tt.want) {
 				t.Errorf("ParseMajorAlias(%q) = (%v, %v), want (%v, %v)", tt.version, got, gotOk, tt.want, tt.wantOk)
-			}
-		})
-	}
-}
-
-func TestSelectHighestForMajor(t *testing.T) {
-	releases := []release{
-		{TagName: "v5.21.3"},
-		{TagName: "v5.22.0", Prerelease: true},
-		{TagName: "v5.22.1", Draft: true},
-		{TagName: "not-a-version"},
-		{TagName: "v5.21.10"},
-		{TagName: "v4.9.3"},
-	}
-
-	tests := []struct {
-		name          string
-		releases      []release
-		major         int64
-		want          string
-		wantOlderSeen bool
-	}{
-		{name: "highest of major", releases: releases, major: 5, want: "5.21.10", wantOlderSeen: true},
-		{name: "older major", releases: releases, major: 4, want: "4.9.3", wantOlderSeen: false},
-		{name: "no match", releases: releases, major: 6, want: "", wantOlderSeen: true},
-		{name: "empty", releases: nil, major: 5, want: "", wantOlderSeen: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			highest, olderSeen := selectHighestForMajor(tt.releases, tt.major)
-			var got string
-			if highest != nil {
-				got = highest.String()
-			}
-			if got != tt.want {
-				t.Errorf("selectHighestForMajor() version = %q, want %q", got, tt.want)
-			}
-			if olderSeen != tt.wantOlderSeen {
-				t.Errorf("selectHighestForMajor() sawOlderMajor = %v, want %v", olderSeen, tt.wantOlderSeen)
 			}
 		})
 	}

--- a/internal/engine/version_test.go
+++ b/internal/engine/version_test.go
@@ -100,6 +100,34 @@ func TestParseMajorAlias(t *testing.T) {
 	}
 }
 
+func TestGetHighestVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		engines []EngineMetadata
+		want    string
+	}{
+		{
+			name:    "highest of several versions",
+			engines: []EngineMetadata{{Version: "4.9.3"}, {Version: "5.21.10"}, {Version: "5.21.3"}},
+			want:    "5.21.10",
+		},
+		{
+			name:    "unparseable versions are ignored",
+			engines: []EngineMetadata{{Version: "dev"}, {Version: "4.9.3"}},
+			want:    "4.9.3",
+		},
+		{name: "no engines", engines: nil, want: ""},
+		{name: "no parseable engines", engines: []EngineMetadata{{Version: "dev"}}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetHighestVersion(tt.engines); got != tt.want {
+				t.Errorf("GetHighestVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetHighestVersionForMajor(t *testing.T) {
 	engines := []EngineMetadata{
 		{Version: "4.9.3"},

--- a/internal/engine/version_test.go
+++ b/internal/engine/version_test.go
@@ -31,6 +31,8 @@ func TestUsesEnvConfig(t *testing.T) {
 		{name: "5.x uses env vars", version: "5.2.3", want: true},
 		{name: "6.x uses env vars", version: "6.0.0", want: true},
 		{name: "5.x pre-release uses env vars", version: "5.0.0-beta.1", want: true},
+		{name: "major alias 4 uses CLI flags", version: "4", want: false},
+		{name: "major alias 5 uses env vars", version: "5", want: true},
 		{name: "unparseable falls back to env vars", version: "dev", want: true},
 		{name: "empty version falls back to env vars", version: "", want: true},
 	}
@@ -55,6 +57,10 @@ func TestDeriveEngineTypeFromVersion(t *testing.T) {
 		{name: "5.x derives native", version: "5.2.3", want: EngineTypeNative},
 		{name: "6.x derives native", version: "6.0.0", want: EngineTypeNative},
 		{name: "5.x pre-release derives native", version: "5.0.0-beta.1", want: EngineTypeNative},
+		{name: "major alias 3 has no derivation", version: "3", want: EngineTypeNone},
+		{name: "major alias 4 has no derivation", version: "4", want: EngineTypeNone},
+		{name: "major alias 5 derives native", version: "5", want: EngineTypeNative},
+		{name: "major alias 6 derives native", version: "6", want: EngineTypeNative},
 		{name: "latest keeps default", version: "latest", want: EngineTypeNone},
 		{name: "empty keeps default", version: "", want: EngineTypeNone},
 		{name: "unparseable keeps default", version: "dev", want: EngineTypeNone},
@@ -63,6 +69,98 @@ func TestDeriveEngineTypeFromVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := DeriveEngineTypeFromVersion(tt.version); got != tt.want {
 				t.Errorf("DeriveEngineTypeFromVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMajorAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    int64
+		wantOk  bool
+	}{
+		{name: "bare major", version: "4", want: 4, wantOk: true},
+		{name: "bare major 5", version: "5", want: 5, wantOk: true},
+		{name: "multi-digit major", version: "10", want: 10, wantOk: true},
+		{name: "full version is not an alias", version: "4.9.3", wantOk: false},
+		{name: "partial version is not an alias", version: "4.9", wantOk: false},
+		{name: "latest is not a major alias", version: "latest", wantOk: false},
+		{name: "empty is not an alias", version: "", wantOk: false},
+		{name: "prefixed major is not an alias", version: "v5", wantOk: false},
+		{name: "negative is not an alias", version: "-5", wantOk: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotOk := ParseMajorAlias(tt.version)
+			if gotOk != tt.wantOk || (gotOk && got != tt.want) {
+				t.Errorf("ParseMajorAlias(%q) = (%v, %v), want (%v, %v)", tt.version, got, gotOk, tt.want, tt.wantOk)
+			}
+		})
+	}
+}
+
+func TestSelectHighestForMajor(t *testing.T) {
+	releases := []release{
+		{TagName: "v5.21.3"},
+		{TagName: "v5.22.0", Prerelease: true},
+		{TagName: "v5.22.1", Draft: true},
+		{TagName: "not-a-version"},
+		{TagName: "v5.21.10"},
+		{TagName: "v4.9.3"},
+	}
+
+	tests := []struct {
+		name          string
+		releases      []release
+		major         int64
+		want          string
+		wantOlderSeen bool
+	}{
+		{name: "highest of major", releases: releases, major: 5, want: "5.21.10", wantOlderSeen: true},
+		{name: "older major", releases: releases, major: 4, want: "4.9.3", wantOlderSeen: false},
+		{name: "no match", releases: releases, major: 6, want: "", wantOlderSeen: true},
+		{name: "empty", releases: nil, major: 5, want: "", wantOlderSeen: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			highest, olderSeen := selectHighestForMajor(tt.releases, tt.major)
+			var got string
+			if highest != nil {
+				got = highest.String()
+			}
+			if got != tt.want {
+				t.Errorf("selectHighestForMajor() version = %q, want %q", got, tt.want)
+			}
+			if olderSeen != tt.wantOlderSeen {
+				t.Errorf("selectHighestForMajor() sawOlderMajor = %v, want %v", olderSeen, tt.wantOlderSeen)
+			}
+		})
+	}
+}
+
+func TestGetHighestVersionForMajor(t *testing.T) {
+	engines := []EngineMetadata{
+		{Version: "4.9.3"},
+		{Version: "5.21.3"},
+		{Version: "5.21.10"},
+		{Version: "dev"},
+	}
+
+	tests := []struct {
+		name  string
+		major int64
+		want  string
+	}{
+		{name: "highest 5.x", major: 5, want: "5.21.10"},
+		{name: "highest 4.x", major: 4, want: "4.9.3"},
+		{name: "none installed for major", major: 6, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetHighestVersionForMajor(engines, tt.major); got != tt.want {
+				t.Errorf("GetHighestVersionForMajor(major=%d) = %q, want %q", tt.major, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Adds a short engine version alias — `4` or `5` — meaning the latest release of that engine line.

## Summary

- `--version 5` (or `version: "5"` in config) resolves to the latest native engine release; `--version 4` resolves to the latest JVM engine release
- The alias alone selects the engine line, so `5` resolves against `imposter-go` and `4` against `imposter-jvm-engine`, independent of the configured engine type
- A `5` alias also derives the native engine type where no engine type is configured, matching the existing behaviour for explicit 5.x versions
- `imposter engine pull` and the `plugin install` / `plugin uninstall` commands now derive the engine type from the version, as `up` and `bundle` already do, so an alias fetches the engine and plugin files that belong together
- `imposter version --full` prefers a locally installed engine matching the configured alias over a releases API lookup
- Resolved aliases are cached in prefs alongside the existing `latest` cache, keyed per repository
- Documents the alias in the README, config reference, and the JVM and native engine guides

## Implementation details

Only `4` and `5` are accepted as aliases, and each maps to the 'latest release' endpoint for its repository — the same call already used for `latest`. Any other bare number is treated as a literal version, as before.

A malformed releases API response with no tag name previously panicked on an unchecked type assertion, and now returns an error.