### PR TITLE
feat: reject version aliases that name the wrong engine line

### DIFF
--- a/docs/engine_jvm.md
+++ b/docs/engine_jvm.md
@@ -53,3 +53,5 @@ The JVM engine is version 4 and below. Passing `--version 4` (or `-v 4`) runs th
 To pin an exact release, pass it in full:
 
     imposter up -t jvm -v 4.9.3
+
+The `5` alias is rejected for this engine type, as version 5 and above is the [native engine](./engine_native.md).

--- a/docs/engine_native.md
+++ b/docs/engine_native.md
@@ -66,6 +66,8 @@ To pin an exact release, pass it in full:
 
     imposter up -v 5.21.3
 
+The `4` alias is rejected for this engine type, as version 4 and below is the [JVM engine](./engine_jvm.md).
+
 ## Differences from the JVM engine
 
 - **No Groovy scripting** - use JavaScript instead

--- a/internal/engine/builder.go
+++ b/internal/engine/builder.go
@@ -193,6 +193,9 @@ func GetConfiguredVersionOrResolve(engineType EngineType, override string, allow
 		return latest
 	}
 	if major, ok := ParseMajorAlias(version); ok {
+		if err := CheckMajorAliasSupported(engineType, version, major); err != nil {
+			logger.Fatal(err)
+		}
 		resolved, err := ResolveMajorToVersion(major, allowCached)
 		if err != nil {
 			panic(err)

--- a/internal/engine/builder_test.go
+++ b/internal/engine/builder_test.go
@@ -108,6 +108,10 @@ func TestGetConfiguredTypeWithVersion(t *testing.T) {
 		{name: "major alias 5 derives native", args: args{versionOverride: "5"}, want: EngineTypeNative},
 		{name: "configured major alias 5 derives native", configureVersion: "5", want: EngineTypeNative},
 		{name: "major alias 4 keeps default", args: args{versionOverride: "4"}, want: defaultEngineType},
+		{name: "explicit type wins over major alias", args: args{typeOverride: "jvm", versionOverride: "5"}, want: EngineTypeJvmSingleJar},
+		{name: "configured type wins over major alias", args: args{versionOverride: "5"}, configureType: "jvm", want: EngineTypeJvmSingleJar},
+		{name: "configured type wins over configured major alias", configureType: "docker", configureVersion: "5", want: EngineTypeDockerCore},
+		{name: "explicit type wins over configured major alias", args: args{typeOverride: "jvm"}, configureVersion: "5", want: EngineTypeJvmSingleJar},
 		{name: "latest keeps default", args: args{versionOverride: "latest"}, want: defaultEngineType},
 		{name: "no version, no type, returns default", want: defaultEngineType},
 	}

--- a/internal/engine/version.go
+++ b/internal/engine/version.go
@@ -66,6 +66,24 @@ func ParseMajorAlias(version string) (int64, bool) {
 	return major, ok
 }
 
+// CheckMajorAliasSupported returns an error if the given major version alias
+// names an engine line that the given engine type cannot run, such as the "5"
+// alias with the JVM engine. Engine types built from both lines - the Docker
+// images and AWS Lambda - accept either alias.
+func CheckMajorAliasSupported(engineType EngineType, alias string, major int64) error {
+	switch engineType {
+	case EngineTypeJvmSingleJar, EngineTypeJvmUnpacked:
+		if major >= 5 {
+			return fmt.Errorf("engine version alias '%s' is not available for the %s engine type - the JVM engine is version 4 and below", alias, engineType)
+		}
+	case EngineTypeNative:
+		if major < 5 {
+			return fmt.Errorf("engine version alias '%s' is not available for the %s engine type - the native engine is version 5 and above", alias, engineType)
+		}
+	}
+	return nil
+}
+
 // parseMajorVersion returns the major component of the given engine version,
 // accepting either a full semver version or a bare major-version alias such as
 // "4". It returns (0, false) if the version can be parsed as neither. Callers

--- a/internal/engine/version_resolve_test.go
+++ b/internal/engine/version_resolve_test.go
@@ -170,7 +170,7 @@ func TestGetConfiguredVersionResolvesAliases(t *testing.T) {
 	}{
 		{name: "alias 5 resolves against the native repo", engineType: EngineTypeDockerCore, override: "5", want: "5.21.3"},
 		{name: "alias 5 resolves against the native repo for lambda", engineType: EngineTypeAwsLambda, override: "5", want: "5.21.3"},
-		{name: "alias 4 resolves against the jvm repo", engineType: EngineTypeNative, override: "4", want: "4.9.3"},
+		{name: "alias 4 resolves against the jvm repo", engineType: EngineTypeAwsLambda, override: "4", want: "4.9.3"},
 		{name: "latest resolves against the engine type", engineType: EngineTypeDockerCore, override: "latest", want: "4.9.1"},
 		{name: "explicit version is not resolved", engineType: EngineTypeDockerCore, override: "4.8.0", want: "4.8.0"},
 	}
@@ -187,6 +187,71 @@ func TestGetConfiguredVersionResolvesAliases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckMajorAliasSupported(t *testing.T) {
+	tests := []struct {
+		name       string
+		engineType EngineType
+		alias      string
+		major      int64
+		wantErr    string
+	}{
+		{name: "jvm engine rejects alias 5", engineType: EngineTypeJvmSingleJar, alias: "5", major: 5, wantErr: "the JVM engine is version 4 and below"},
+		{name: "unpacked engine rejects alias 5", engineType: EngineTypeJvmUnpacked, alias: "5", major: 5, wantErr: "the JVM engine is version 4 and below"},
+		{name: "native engine rejects alias 4", engineType: EngineTypeNative, alias: "4", major: 4, wantErr: "the native engine is version 5 and above"},
+		{name: "jvm engine accepts alias 4", engineType: EngineTypeJvmSingleJar, alias: "4", major: 4},
+		{name: "native engine accepts alias 5", engineType: EngineTypeNative, alias: "5", major: 5},
+		// docker images and lambda are built from both engine lines
+		{name: "docker engine accepts alias 4", engineType: EngineTypeDockerCore, alias: "4", major: 4},
+		{name: "docker engine accepts alias 5", engineType: EngineTypeDockerCore, alias: "5", major: 5},
+		{name: "lambda accepts alias 4", engineType: EngineTypeAwsLambda, alias: "4", major: 4},
+		{name: "lambda accepts alias 5", engineType: EngineTypeAwsLambda, alias: "5", major: 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckMajorAliasSupported(tt.engineType, tt.alias, tt.major)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckMajorAliasSupported() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CheckMajorAliasSupported() error = nil, want it to contain %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("CheckMajorAliasSupported() error = %q, want it to contain %q", err, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("alias '%s'", tt.alias)) {
+				t.Errorf("CheckMajorAliasSupported() error = %q, want it to name the alias", err)
+			}
+		})
+	}
+}
+
+// TestGetConfiguredVersionRejectsUnsupportedAlias checks that an alias naming
+// the wrong engine line fails before any attempt to fetch that version.
+func TestGetConfiguredVersionRejectsUnsupportedAlias(t *testing.T) {
+	useTempPrefs(t)
+
+	oldExitFunc := logger.ExitFunc
+	logger.ExitFunc = func(code int) {
+		panic(fmt.Sprintf("fatal exit with code %d", code))
+	}
+	t.Cleanup(func() {
+		logger.ExitFunc = oldExitFunc
+	})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("GetConfiguredVersion() returned normally, want a fatal exit")
+		}
+	}()
+
+	// resolving would need the API, so a fatal exit here also proves the
+	// check happens before the version is looked up
+	GetConfiguredVersion(EngineTypeJvmSingleJar, "5", true)
 }
 
 func TestGetRepoNameForMajor(t *testing.T) {


### PR DESCRIPTION
Fails fast when an engine version alias names an engine line the configured engine type cannot run, and pins the existing precedence of engine type over version.

## Summary

- `-t jvm -v 5` and `-t native -v 4` now fail with a message naming the mismatch, instead of resolving a version that engine has no release for and failing later with a 404 from the download
- The Docker images and AWS Lambda are built from both engine lines, so they continue to accept either alias
- Adds test cases pinning that an engine type configured via `-t`, `imposter-project.yaml`, `~/.imposter/config.yaml` or `IMPOSTER_ENGINE` takes precedence over the type derived from a version alias — this was already the behaviour, and was only covered for full versions such as `5.0.0`
- Documents the rejected combinations in the JVM and native engine guides

## Implementation details

The check runs before the alias is resolved, so an unsupported combination never reaches the releases API. Only aliases are validated — an explicit version such as `-t jvm -v 5.21.3` is left alone, since pinning an exact version stays the user's call.

Before:

```
$ imposter up -t jvm -v 5
DEBUG downloading .../imposter-jvm-engine/releases/download/v5.21.3/imposter-5.21.3.jar
FATAL failed to fetch binary: error downloading from: ...: status code: 404
```

After:

```
$ imposter up -t jvm -v 5
FATAL engine version alias '5' is not available for the jvm engine type - the JVM engine is version 4 and below
```